### PR TITLE
Add Feature to Allow Templating of Classpath Resources.

### DIFF
--- a/gstring-maven-plugin/pom.xml
+++ b/gstring-maven-plugin/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>groovy-all</artifactId>
 			<version>2.1.1</version>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/gstring-maven-plugin/src/test/java/org/jboss/tools/maven/gstring/ProcessTemplateFilesMojoTest.java
+++ b/gstring-maven-plugin/src/test/java/org/jboss/tools/maven/gstring/ProcessTemplateFilesMojoTest.java
@@ -44,6 +44,29 @@ public class ProcessTemplateFilesMojoTest extends AbstractMojoTestCase {
         stream.close();
 	}
 
+    @Test
+    public void testTemplateFromResource() throws Exception {
+        File pom = getTestFile( "src/test/resources/pom-testResourceTemplate.xml" );
+        assertNotNull( pom );
+        assertTrue( pom.exists() );
+
+        ProcessTemplateFilesMojo myMojo = (ProcessTemplateFilesMojo) lookupMojo( "process-templates", pom );
+        assertNotNull( myMojo );
+        myMojo.execute();
+
+        File outputFile = getTestFile("target/testOutput/template.txt");
+        FileInputStream stream = new FileInputStream(outputFile);
+        byte[] bytes = new byte[(int)outputFile.length()];
+        stream.read(bytes);
+        String outputText = new String(bytes);
+        Assert.assertEquals(
+            "Hello world !\n" +
+                "Hello WORLD !\n\n" +
+                "Hello WORLD (from a closure) !",
+            outputText);
+        stream.close();
+    }
+
 	@Test
 	public void testBadTemplatePath() throws Exception {
 		File pom = getTestFile( "src/test/resources/pom-testBadTemplatePath.xml" );

--- a/gstring-maven-plugin/src/test/resources/pom-testResourceTemplate.xml
+++ b/gstring-maven-plugin/src/test/resources/pom-testResourceTemplate.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>project-to-test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Test MyMojo</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>3.8.1</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>gstring-maven-plugin</artifactId>
+				<configuration>
+					<outputDirectory>target/testOutput</outputDirectory>
+                    <resources>
+                        <resource>template.txt</resource>
+                    </resources>
+					<symbols>
+						<place>world</place>
+					</symbols>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
I had the need to template a file that was from a shared module. The current version of `gstring-maven-plugin` only supports actual files. 

This PR adds support for `resources` and it looks for the paths on the classpath. 

This allows one to use a path coming from another artifact like this:

```
             <plugin>
                <groupId>org.jboss.tools.maven</groupId>
                <artifactId>gstring-maven-plugin</artifactId>
                <version>1.1.0-SNAPSHOT</version>
                <dependencies>
                    <dependency>
                        <groupId>other.groupId</groupId>
                        <artifactId>artifactIdWithTemplateResource</artifactId>
                        <version>1.0.0</version>
                    </dependency>
                </dependencies>
                <executions>
                    <execution>
                        <id>create-script</id>
                        <phase>package</phase>
                        <goals>
                            <goal>process-templates</goal>
                        </goals>
                        <configuration>
                            <resources>
                                <resource>path/to/resource/in/dependency</resource>
                            </resources>
                            <symbols>
                                ...
                            </symbols>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```
